### PR TITLE
Removed needless droplet id arg

### DIFF
--- a/doboto/Droplet.py
+++ b/doboto/Droplet.py
@@ -67,7 +67,7 @@ class Droplet(Endpoint):
         uri = "%s/%s/actions/%s" % (self.uri, droplet_id, action_id)
         return self.make_request(uri)
 
-    def destroy(self, droplet_id, with_tag=None):
+    def destroy(self, droplet_id=None, with_tag=None):
         """
         Destroy a droplet of tagged droplets
         """

--- a/doboto/Droplet.py
+++ b/doboto/Droplet.py
@@ -73,8 +73,10 @@ class Droplet(Endpoint):
         """
         if with_tag is not None:
             uri = "%s?tag_name=%s" % (self.uri, with_tag)
-        else:
+        elif droplet_id is not None:
             uri = "%s/%s" % (self.uri, droplet_id)
+        else:
+            raise ValueError("droplet_id or with_tag must be specified")
         return self.make_request(uri, 'DELETE')
 
     def create(self, attribs=None):

--- a/tests/test_Droplet.py
+++ b/tests/test_Droplet.py
@@ -158,7 +158,7 @@ class TestDroplet(TestCase):
         mock_make_request.assert_called_with(test_uri, 'DELETE')
 
         tag = "rando-tag"
-        drop.destroy("all", with_tag=tag)
+        drop.destroy(with_tag=tag)
         test_uri = "{}?tag_name={}".format(self.test_uri, tag)
 
         mock_make_request.assert_called_with(test_uri, 'DELETE')

--- a/tests/test_Droplet.py
+++ b/tests/test_Droplet.py
@@ -163,6 +163,9 @@ class TestDroplet(TestCase):
 
         mock_make_request.assert_called_with(test_uri, 'DELETE')
 
+        with self.assertRaises(ValueError):
+            drop.destroy()
+
     @patch('doboto.Droplet.Droplet.make_request')
     def test_create(self, mock_make_request):
         """


### PR DESCRIPTION
You can delete by tag alone through the API, shouldn't have to send a bogus droplet_id.