### PR TITLE
Tag consistent name

### DIFF
--- a/doboto/Tag.py
+++ b/doboto/Tag.py
@@ -25,12 +25,12 @@ class Tag(Endpoint):
 
         return self.make_request(self.uri, 'POST', attribs)
 
-    def info(self, tag_name):
+    def info(self, name):
         """
         Retrieve a tag
         """
 
-        uri = "%s/%s" % (self.uri, tag_name)
+        uri = "%s/%s" % (self.uri, name)
         return self.make_request(uri)
 
     def list(self):
@@ -40,43 +40,43 @@ class Tag(Endpoint):
 
         return self.make_request(self.uri)
 
-    def update(self, tag_name, name):
+    def update(self, name, new_name):
         """
         This call provides a way to rename an existing tag
         """
 
-        uri = "{}/{}".format(self.uri, tag_name)
-        attribs = {'name': name}
+        uri = "{}/{}".format(self.uri, name)
+        attribs = {'name': new_name}
 
         return self.make_request(uri, 'PUT', attribs)
 
-    def attach(self, tag_name, resources):
+    def attach(self, name, resources):
         """
         This call provides a way to attach resources to a tag
         """
 
-        uri = "{}/{}/resources".format(self.uri, tag_name)
+        uri = "{}/{}/resources".format(self.uri, name)
         attribs = {'resources': resources}
 
         return self.make_request(uri, 'POST', attribs)
 
-    def detach(self, tag_name, resources):
+    def detach(self, name, resources):
         """
         This call provides a way to detach resources to a tag
         """
 
-        uri = "{}/{}/resources".format(self.uri, tag_name)
+        uri = "{}/{}/resources".format(self.uri, name)
         attribs = {'resources': resources}
 
         return self.make_request(uri, 'DELETE', attribs)
 
-    def destroy(self, tag_name):
+    def destroy(self, name):
         """
         Removes a named tag from all resources it is associated with, and
         deletes the tag itself
         """
 
-        uri = "{}/{}".format(self.uri, tag_name)
+        uri = "{}/{}".format(self.uri, name)
 
         return self.make_request(uri, 'DELETE')
 

--- a/tests/test_Tag.py
+++ b/tests/test_Tag.py
@@ -61,7 +61,7 @@ class TestTag(TestCase):
     @patch('doboto.Tag.Tag.make_request')
     def test_info(self, mock_make_request):
         """
-        info works with tag_name
+        info works with name
         """
 
         mock_ret = {
@@ -70,13 +70,13 @@ class TestTag(TestCase):
         }
 
         mock_make_request.return_value = mock_ret
-        tag_name = "hay"
+        name = "hay"
         tag = self.klass(self.test_url, self.test_token)
-        result = tag.info(tag_name)
+        result = tag.info(name)
 
         self.assertEqual(result, mock_ret)
 
-        test_uri = "{}/{}".format(self.test_uri, tag_name)
+        test_uri = "{}/{}".format(self.test_uri, name)
         mock_make_request.assert_called_with(test_uri)
 
     @patch('doboto.Tag.Tag.make_request')
@@ -160,15 +160,15 @@ class TestTag(TestCase):
         """
 
         extra_data = {'droplet': 'some data', 'your aunt': 'bessie', 'a moose once bit': 'my sister'}
-        tag_names = ['alpha', 'beta', 'gamma']
-        mock_ret = {'tags': [{'name': _, 'resources': extra_data} for _ in tag_names]}
+        names = ['alpha', 'beta', 'gamma']
+        mock_ret = {'tags': [{'name': _, 'resources': extra_data} for _ in names]}
 
 
         mock_make_request.return_value = mock_ret
         tag = self.klass(self.test_uri, self.test_token)
         result = tag.names()
 
-        self.assertListEqual(result, tag_names)
+        self.assertListEqual(result, names)
 
     @patch('doboto.Tag.Tag.make_request')
     def test_names_happy_without_tags(self, mock_make_request):


### PR DESCRIPTION
So like id in droplet, name is the id for tag, and listed as name in all the JSON, thus the arg's been renamed to match.